### PR TITLE
Remove workaround for Python issue 11380

### DIFF
--- a/kinesis_logs_reader/__main__.py
+++ b/kinesis_logs_reader/__main__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, unicode_literals
 from argparse import ArgumentParser
 from datetime import datetime
-from errno import EPIPE
 from itertools import chain
 import sys
 
@@ -19,11 +18,7 @@ def print_stream(stream_name, start_time, stop_after):
     # Join the first row with the rest of the rows and print them
     iterable = chain([first_row], reader)
     for i, fields in enumerate(iterable, 1):
-        try:
-            print(*[fields[k] for k in keys], sep='\t')
-        except IOError as e:
-            if e.errno == EPIPE:
-                pass
+        print(*[fields[k] for k in keys], sep='\t')
         if i == stop_after:
             break
 
@@ -64,4 +59,3 @@ def main(argv=None):
 
 if __name__ == '__main__':
     main()
-    sys.stdout.close()


### PR DESCRIPTION
These lines were an attempt to work around [this issue](http://bugs.python.org/issue11380) when piping to `head`, but further research shows that this problem is (a) cosmetic, (b) more trouble to "fix" than it's worth, (c) mitigated by the inclusion of the `--count` argument.

[This StackOverflow answer](http://stackoverflow.com/a/35761190/353839) has a valiant attempt to work around the issue, but it seems a bridge too far.